### PR TITLE
Add Custom Request Headers

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/compat-layers/apigw-lambda-compat/package.json
+++ b/packages/compat-layers/apigw-lambda-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/next-aws-lambda",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Compat layer between next.js serverless page and AWS Lambda",
   "files": [
     "lib/**",

--- a/packages/compat-layers/lambda-at-edge-compat/package.json
+++ b/packages/compat-layers/lambda-at-edge-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/next-aws-cloudfront",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Compat layer for running next.js apps in Lambda@Edge",
   "main": "next-aws-cloudfront.js",
   "types": "next-aws-cloudfront.d.ts",

--- a/packages/libs/aws-common/package.json
+++ b/packages/libs/aws-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-common",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Common AWS code that is used in Lambda, Lambda@Edge and other AWS platforms.",
   "main": "dist/index.js",
   "module": "dist/module/index.js",

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/cloudfront",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Handles CloudFront invalidation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/core/package.json
+++ b/packages/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/core",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Handles Next.js routing independent of provider",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/core/src/defaultHandler.ts
+++ b/packages/libs/core/src/defaultHandler.ts
@@ -48,18 +48,12 @@ const createExternalRewriteResponse = async (
   customRewrite: string,
   req: IncomingMessage,
   res: ServerResponse,
-  body?: string,
-  customRequestHeaders?: Header[]
+  platformClient: PlatformClient,
+  body?: string
 ): Promise<void> => {
   // Set request headers
   const reqHeaders: any = {};
   Object.assign(reqHeaders, req.headers);
-
-  if (customRequestHeaders) {
-    customRequestHeaders.forEach((header) => {
-      reqHeaders[header.key] = header.value;
-    });
-  }
 
   // Delete host header otherwise request may fail due to host mismatch
   if (reqHeaders.hasOwnProperty("host")) {
@@ -97,7 +91,7 @@ const externalRewrite = async (
   req: IncomingMessage,
   res: ServerResponse,
   rewrite: string,
-  customRequestHeaders?: Header[]
+  platformClient: PlatformClient
 ): Promise<void> => {
   const querystring = req.url?.includes("?") ? req.url?.split("?") : "";
   let body = "";
@@ -109,8 +103,8 @@ const externalRewrite = async (
     rewrite + (querystring ? "?" : "") + querystring,
     req,
     res,
-    body,
-    customRequestHeaders
+    platformClient,
+    body
   );
 };
 
@@ -422,5 +416,5 @@ export const defaultHandler = async ({
 
   const external: ExternalRoute = route;
   const { path } = external;
-  return await externalRewrite(req, res, path, manifest.customRequestHeaders);
+  return await externalRewrite(req, res, path, platformClient);
 };

--- a/packages/libs/core/src/defaultHandler.ts
+++ b/packages/libs/core/src/defaultHandler.ts
@@ -1,4 +1,5 @@
 import {
+  Header,
   NextStaticFileRoute,
   PerfLogger,
   PreRenderedManifest as PrerenderManifestType
@@ -47,12 +48,18 @@ const createExternalRewriteResponse = async (
   customRewrite: string,
   req: IncomingMessage,
   res: ServerResponse,
-  platformClient: PlatformClient,
-  body?: string
+  body?: string,
+  customRequestHeaders?: Header[]
 ): Promise<void> => {
   // Set request headers
   const reqHeaders: any = {};
   Object.assign(reqHeaders, req.headers);
+
+  if (customRequestHeaders) {
+    customRequestHeaders.forEach((header) => {
+      reqHeaders[header.key] = header.value;
+    });
+  }
 
   // Delete host header otherwise request may fail due to host mismatch
   if (reqHeaders.hasOwnProperty("host")) {
@@ -90,7 +97,7 @@ const externalRewrite = async (
   req: IncomingMessage,
   res: ServerResponse,
   rewrite: string,
-  platformClient: PlatformClient
+  customRequestHeaders?: Header[]
 ): Promise<void> => {
   const querystring = req.url?.includes("?") ? req.url?.split("?") : "";
   let body = "";
@@ -102,8 +109,8 @@ const externalRewrite = async (
     rewrite + (querystring ? "?" : "") + querystring,
     req,
     res,
-    platformClient,
-    body
+    body,
+    customRequestHeaders
   );
 };
 
@@ -415,5 +422,5 @@ export const defaultHandler = async ({
 
   const external: ExternalRoute = route;
   const { path } = external;
-  return await externalRewrite(req, res, path, platformClient);
+  return await externalRewrite(req, res, path, manifest.customRequestHeaders);
 };

--- a/packages/libs/core/src/defaultHandler.ts
+++ b/packages/libs/core/src/defaultHandler.ts
@@ -1,5 +1,4 @@
 import {
-  Header,
   NextStaticFileRoute,
   PerfLogger,
   PreRenderedManifest as PrerenderManifestType

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -2,6 +2,11 @@
 import { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "http";
 
 export type Header = {
+  key?: string;
+  value: string;
+};
+
+export type CustomHeader = {
   key: string;
   value: string;
 };
@@ -69,7 +74,7 @@ export type Manifest = {
     [key: string]: string;
   };
   trailingSlash?: boolean;
-  customRequestHeaders?: Header[];
+  customRequestHeaders?: CustomHeader[];
 };
 
 export type ApiManifest = Manifest & {

--- a/packages/libs/core/src/types.ts
+++ b/packages/libs/core/src/types.ts
@@ -2,7 +2,7 @@
 import { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "http";
 
 export type Header = {
-  key?: string;
+  key: string;
   value: string;
 };
 
@@ -69,6 +69,7 @@ export type Manifest = {
     [key: string]: string;
   };
   trailingSlash?: boolean;
+  customRequestHeaders?: Header[];
 };
 
 export type ApiManifest = Manifest & {

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/lambda-at-edge",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -52,6 +52,7 @@ type BuildOptions = {
   separateApiLambda?: boolean;
   disableOriginResponseHandler?: boolean;
   useV2Handler?: boolean;
+  customRequestHeaders?: { key: string; value: string }[];
 };
 
 const defaultBuildOptions = {

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -7,7 +7,8 @@ import {
   OriginRequestDefaultHandlerManifest,
   OriginRequestApiHandlerManifest,
   RoutesManifest,
-  OriginRequestImageHandlerManifest
+  OriginRequestImageHandlerManifest,
+  CustomHeader
 } from "./types";
 import pathToPosix from "@sls-next/core/dist/build/lib/pathToPosix";
 import normalizeNodeModules from "@sls-next/core/dist/build/lib/normalizeNodeModules";
@@ -52,7 +53,7 @@ type BuildOptions = {
   separateApiLambda?: boolean;
   disableOriginResponseHandler?: boolean;
   useV2Handler?: boolean;
-  customRequestHeaders?: { key: string; value: string }[];
+  customRequestHeaders?: CustomHeader[];
 };
 
 const defaultBuildOptions = {

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -93,6 +93,9 @@ class Builder {
     this.nextStaticDir = path.resolve(nextStaticDir ?? nextConfigDir);
     this.dotNextDir = path.join(this.nextConfigDir, ".next");
     this.serverlessDir = path.join(this.dotNextDir, "serverless");
+
+    console.warn("buildOptions", buildOptions);
+
     this.outputDir = outputDir;
     if (buildOptions) {
       this.buildOptions = buildOptions;
@@ -291,6 +294,7 @@ class Builder {
       join(this.serverlessDir, "pages/api")
     );
 
+    console.log("buildDefaultLambda:buildManifest", buildManifest);
     return Promise.all([
       this.copyTraces(buildManifest, DEFAULT_LAMBDA_CODE_DIR),
       this.processAndCopyHandler(
@@ -732,7 +736,8 @@ class Builder {
       cleanupDotNext,
       assetIgnorePatterns,
       separateApiLambda,
-      useV2Handler
+      useV2Handler,
+      customRequestHeaders
     } = Object.assign(defaultBuildOptions, this.buildOptions);
 
     await Promise.all([
@@ -813,7 +818,8 @@ class Builder {
       enableHTTPCompression,
       logLambdaExecutionTimes,
       regenerationQueueName,
-      disableOriginResponseHandler
+      disableOriginResponseHandler,
+      customRequestHeaders
     };
     const imageBuildManifest = {
       ...imageManifest,

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -21,6 +21,7 @@ import { prepareBuildManifests } from "@sls-next/core";
 import { NextConfig } from "@sls-next/core";
 import { NextI18nextIntegration } from "@sls-next/core/dist/build/third-party/next-i18next";
 import normalizePath from "normalize-path";
+import { loadCustomRequestHeaders } from "./load-custom-headers";
 
 export const DEFAULT_LAMBDA_CODE_DIR = "default-lambda";
 export const API_LAMBDA_CODE_DIR = "api-lambda";
@@ -738,8 +739,12 @@ class Builder {
       assetIgnorePatterns,
       separateApiLambda,
       useV2Handler,
-      customRequestHeaders
+      customRequestHeaders: rawCustomRequestHeaders
     } = Object.assign(defaultBuildOptions, this.buildOptions);
+
+    const customRequestHeaders = loadCustomRequestHeaders(
+      rawCustomRequestHeaders
+    );
 
     await Promise.all([
       this.cleanupDotNext(cleanupDotNext),

--- a/packages/libs/lambda-at-edge/src/build.ts
+++ b/packages/libs/lambda-at-edge/src/build.ts
@@ -96,8 +96,6 @@ class Builder {
     this.dotNextDir = path.join(this.nextConfigDir, ".next");
     this.serverlessDir = path.join(this.dotNextDir, "serverless");
 
-    console.warn("buildOptions", buildOptions);
-
     this.outputDir = outputDir;
     if (buildOptions) {
       this.buildOptions = buildOptions;
@@ -296,7 +294,6 @@ class Builder {
       join(this.serverlessDir, "pages/api")
     );
 
-    console.log("buildDefaultLambda:buildManifest", buildManifest);
     return Promise.all([
       this.copyTraces(buildManifest, DEFAULT_LAMBDA_CODE_DIR),
       this.processAndCopyHandler(

--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -292,7 +292,12 @@ const handleOriginRequest = async ({
 
   const external: ExternalRoute = route;
   const { path } = external;
-  return externalRewrite(event, manifest.enableHTTPCompression, path);
+  return externalRewrite(
+    event,
+    manifest.enableHTTPCompression,
+    path,
+    manifest.customRequestHeaders
+  );
 };
 
 const handleOriginResponse = async ({

--- a/packages/libs/lambda-at-edge/src/load-custom-headers.ts
+++ b/packages/libs/lambda-at-edge/src/load-custom-headers.ts
@@ -20,6 +20,11 @@ export const loadCustomRequestHeaders = (
   for (const header of headers) {
     const invalidHeaderParts: string[] = [];
 
+    if (header === undefined || typeof header !== "object") {
+      invalidHeaderParts.push(`invalid header ${JSON.stringify(header)}`);
+      continue;
+    }
+
     if (typeof header.key !== "string") {
       invalidHeaderParts.push(`invalid key "${header.key}"`);
     }

--- a/packages/libs/lambda-at-edge/src/load-custom-headers.ts
+++ b/packages/libs/lambda-at-edge/src/load-custom-headers.ts
@@ -1,0 +1,53 @@
+import { CustomHeader } from "./types";
+
+const allowedProperties = new Set<string>(["key", "value"]);
+
+export const loadCustomRequestHeaders = (
+  headers: CustomHeader[] | undefined
+): CustomHeader[] | undefined => {
+  if (headers === undefined) {
+    return headers;
+  }
+
+  if (!Array.isArray(headers)) {
+    throw new Error(
+      `CustomRequestHeaders: must be undefined or an array of header objects, received ${typeof headers}`
+    );
+  }
+
+  const invalidHeaders = [];
+
+  for (const header of headers) {
+    const invalidHeaderParts: string[] = [];
+
+    if (typeof header.key !== "string") {
+      invalidHeaderParts.push(`invalid key "${header.key}"`);
+    }
+
+    if (typeof header.value !== "string") {
+      invalidHeaderParts.push(`invalid value "${header.value}"`);
+    }
+
+    for (const headerProperty in header) {
+      if (!allowedProperties.has(headerProperty)) {
+        invalidHeaderParts.push(
+          `unsupported header property "${headerProperty}"`
+        );
+      }
+    }
+
+    if (invalidHeaderParts.length > 0) {
+      invalidHeaders.push(
+        `${invalidHeaderParts.join(", ")} for ${JSON.stringify(header)}`
+      );
+    }
+  }
+
+  if (invalidHeaders.length > 0) {
+    throw new Error(
+      `Invalid \`CustomRequestHeaders\` ${invalidHeaders.join("\n")}`
+    );
+  }
+
+  return headers;
+};

--- a/packages/libs/lambda-at-edge/src/routing/rewriter.ts
+++ b/packages/libs/lambda-at-edge/src/routing/rewriter.ts
@@ -1,5 +1,5 @@
 import { IncomingMessage, ServerResponse } from "http";
-import { OriginRequestEvent, Header } from "../types";
+import { OriginRequestEvent, CustomHeader } from "../types";
 import lambdaAtEdgeCompat from "@sls-next/next-aws-cloudfront";
 import { CloudFrontResultResponse } from "aws-lambda";
 
@@ -45,7 +45,7 @@ export async function createExternalRewriteResponse(
   req: IncomingMessage,
   res: ServerResponse,
   body?: string,
-  customRequestHeaders?: Header[]
+  customRequestHeaders?: CustomHeader[]
 ): Promise<void> {
   const { default: fetch } = await import("node-fetch");
 
@@ -98,7 +98,7 @@ export const externalRewrite: (
   event: OriginRequestEvent,
   enableHTTPCompression: boolean | undefined,
   rewrite: string,
-  customRequestHeaders?: Header[]
+  customRequestHeaders?: CustomHeader[]
 ) => Promise<CloudFrontResultResponse> = async (
   event: OriginRequestEvent,
   enableHTTPCompression: boolean | undefined,

--- a/packages/libs/lambda-at-edge/src/routing/rewriter.ts
+++ b/packages/libs/lambda-at-edge/src/routing/rewriter.ts
@@ -65,8 +65,6 @@ export async function createExternalRewriteResponse(
   }
 
   let fetchResponse;
-  console.warn("createExternalRewriteResponse:reqHeaders", reqHeaders);
-
   if (body) {
     const decodedBody = Buffer.from(body, "base64").toString("utf8");
 

--- a/packages/libs/lambda-at-edge/src/types.ts
+++ b/packages/libs/lambda-at-edge/src/types.ts
@@ -8,7 +8,7 @@ export {
   ImageConfig,
   ImagesManifest
 } from "@sls-next/core/dist/module/build/types";
-export { RoutesManifest, Header } from "@sls-next/core/dist/module/types";
+export { RoutesManifest, CustomHeader } from "@sls-next/core/dist/module/types";
 
 export type OriginRequestApiHandlerManifest = ApiManifest & {
   enableHTTPCompression?: boolean;

--- a/packages/libs/lambda-at-edge/src/types.ts
+++ b/packages/libs/lambda-at-edge/src/types.ts
@@ -8,7 +8,7 @@ export {
   ImageConfig,
   ImagesManifest
 } from "@sls-next/core/dist/module/build/types";
-export { RoutesManifest } from "@sls-next/core/dist/module/types";
+export { RoutesManifest, Header } from "@sls-next/core/dist/module/types";
 
 export type OriginRequestApiHandlerManifest = ApiManifest & {
   enableHTTPCompression?: boolean;

--- a/packages/libs/lambda-at-edge/tests/build/load-custom-headers.test.ts
+++ b/packages/libs/lambda-at-edge/tests/build/load-custom-headers.test.ts
@@ -1,0 +1,50 @@
+import { loadCustomRequestHeaders } from "../../src/load-custom-headers";
+
+describe("loadCustomRequestHeaders", () => {
+  it("returns correct Headers", () => {
+    const headers = [{ key: "headerkey", value: "headervalue" }];
+    expect(loadCustomRequestHeaders(headers)).toBe(headers);
+  });
+
+  it("returns undefined if no Headers", () => {
+    expect(loadCustomRequestHeaders(undefined)).toBe(undefined);
+  });
+
+  it("throws when Headers are not an array", () => {
+    expect(() => {
+      loadCustomRequestHeaders({} as any);
+    }).toThrow();
+  });
+
+  it("throws when uknown property in Headers presented", () => {
+    expect(() => {
+      loadCustomRequestHeaders([
+        {
+          key: "headerkey",
+          value: "headervalue",
+          unsupported: "unsupportedprop"
+        }
+      ]);
+    }).toThrow();
+  });
+
+  it("throws when properties has wrong type", () => {
+    expect(() => {
+      loadCustomRequestHeaders([
+        {
+          key: [],
+          value: undefined
+        }
+      ]);
+    }).toThrow();
+
+    expect(() => {
+      loadCustomRequestHeaders([
+        {
+          key: "headerkey",
+          value: {}
+        }
+      ]);
+    }).toThrow();
+  });
+});

--- a/packages/libs/lambda/package.json
+++ b/packages/libs/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/lambda",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Code to build and deploy for Lambda + API Gateway",
   "main": "dist/index.js",
   "module": "dist/module/index.js",

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/s3-static-assets",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Handles upload to S3 of next.js static assets",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-cloudfront",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",
   "scripts": {

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-lambda",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "main": "serverless.js",
   "keywords": [
     "AWS",

--- a/packages/serverless-components/aws-s3/package.json
+++ b/packages/serverless-components/aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-s3",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "main": "./serverless.js",
   "scripts": {
     "lint": "eslint . --fix --cache",

--- a/packages/serverless-components/aws-sqs/package.json
+++ b/packages/serverless-components/aws-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-sqs",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "main": "serverless.js",
   "scripts": {
     "test": "jest"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/domain",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "main": "serverless.js",
   "scripts": {
     "clean": "yarn rimraf dist",

--- a/packages/serverless-components/nextjs-cdk-construct/package.json
+++ b/packages/serverless-components/nextjs-cdk-construct/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sls-next/cdk-construct",
   "description": "Serverless Next.js powered by AWS CDK",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Henry Kirkness <henry@planes.studio>",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/serverless-component",
-  "version": "3.8.0-alpha.0-republic",
+  "version": "3.8.0-alpha.0-republic.2",
   "description": "Serverless Next.js powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",

--- a/packages/serverless-components/nextjs-component/src/component.ts
+++ b/packages/serverless-components/nextjs-component/src/component.ts
@@ -258,7 +258,8 @@ class NextjsComponent extends Component {
           separateApiLambda: buildConfig.separateApiLambda ?? true,
           disableOriginResponseHandler:
             buildConfig.disableOriginResponseHandler ?? false,
-          useV2Handler: buildConfig.useV2Handler ?? false
+          useV2Handler: buildConfig.useV2Handler ?? false,
+          customRequestHeaders: buildConfig.customRequestHeaders
         },
         nextStaticPath
       );

--- a/packages/serverless-components/nextjs-component/types.d.ts
+++ b/packages/serverless-components/nextjs-component/types.d.ts
@@ -93,6 +93,7 @@ export type BuildOptions = {
   separateApiLambda?: boolean;
   disableOriginResponseHandler?: boolean;
   useV2Handler?: boolean;
+  customRequestHeaders?: { key: string; value: string }[];
 };
 
 export type LambdaType =


### PR DESCRIPTION
[Issue](https://linear.app/republic/issue/RCE-1442/[fw-task-serverless]-extend-serverless-nextjs-to-support)

It extends serverless-next.js to support `customRequestHeaders`

`customRequestHeaders` can be provided in `serverless.yml` and will be attached to the external rewrite request.

API (yml):
```yml
inputs:
  build:
    customRequestHeaders:
      - key: x-custom-header
        value: 'custom-header-value'
```

API (json):
```json
{
  "inputs": {
    "build": {
      "customRequestHeaders": [
        {
          "key": "x-custom-header",
          "value": "custom-header-value"
        }
      ]
    }
  }
}
```