### PR TITLE
Split set-cookie headers from string to array

### DIFF
--- a/packages/libs/lambda-at-edge/src/default-handler.ts
+++ b/packages/libs/lambda-at-edge/src/default-handler.ts
@@ -54,6 +54,7 @@ import { createRedirectResponse } from "@sls-next/core/dist/module/route/redirec
 import { redirectByPageProps } from "@sls-next/core/dist/module/handle/redirect";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import getStream from "get-stream";
+import { normalizeSetCookieHeaders } from "./headers/normalize-set-cookie-headers";
 
 const basePath = RoutesManifestJson.basePath;
 
@@ -128,6 +129,7 @@ export const handler = async (
   // Remove blacklisted headers
   if (response.headers) {
     removeBlacklistedHeaders(response.headers);
+    normalizeSetCookieHeaders(response.headers);
   }
 
   const tHandlerEnd = now();

--- a/packages/libs/lambda-at-edge/src/headers/normalize-set-cookie-headers.ts
+++ b/packages/libs/lambda-at-edge/src/headers/normalize-set-cookie-headers.ts
@@ -1,0 +1,107 @@
+import { CloudFrontHeaders } from "aws-lambda";
+
+const HEADER_NAME = "set-cookie";
+
+function isSetCookieHeader(name: string): boolean {
+  return name.toLowerCase() === HEADER_NAME;
+}
+
+export function normalizeSetCookieHeaders(headers: CloudFrontHeaders) {
+  for (const headerName in headers) {
+    if (!isSetCookieHeader(headerName)) {
+      continue;
+    }
+
+    const setCookieHeaderList = headers[headerName];
+    const normalizedSetCookieHeaderList: CloudFrontHeaders["key"] = [];
+
+    for (const headerItem of setCookieHeaderList) {
+      const { key, value } = headerItem;
+      const setCookieHeaderValues = splitCookiesString(value);
+      setCookieHeaderValues.forEach((setCookieHeaderValue) => {
+        normalizedSetCookieHeaderList.push({
+          key,
+          value: setCookieHeaderValue
+        });
+      });
+    }
+
+    headers[headerName] = normalizedSetCookieHeaderList;
+  }
+}
+
+/*
+  Set-Cookie header field-values are sometimes comma joined in one string. This splits them without choking on commas
+  that are within a single set-cookie field-value, such as in the Expires portion.
+  This is uncommon, but explicitly allowed - see https://tools.ietf.org/html/rfc2616#section-4.2
+  Node.js does this for every header *except* set-cookie - see https://github.com/nodejs/node/blob/d5e363b77ebaf1caf67cd7528224b651c86815c1/lib/_http_incoming.js#L128
+  React Native's fetch does this for *every* header, including set-cookie.
+
+  Based on: https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
+  Credits to: https://github.com/tomball for original and https://github.com/chrusart for JavaScript implementation
+*/
+export function splitCookiesString(cookiesString: string): string[] {
+  const cookiesStrings = [];
+  let pos = 0;
+  let start;
+  let ch;
+  let lastComma;
+  let nextStart;
+  let cookiesSeparatorFound;
+
+  function skipWhitespace() {
+    while (pos < cookiesString.length && /\s/.test(cookiesString.charAt(pos))) {
+      pos += 1;
+    }
+    return pos < cookiesString.length;
+  }
+
+  function notSpecialChar() {
+    ch = cookiesString.charAt(pos);
+
+    return ch !== "=" && ch !== ";" && ch !== ",";
+  }
+
+  while (pos < cookiesString.length) {
+    start = pos;
+    cookiesSeparatorFound = false;
+
+    while (skipWhitespace()) {
+      ch = cookiesString.charAt(pos);
+      if (ch === ",") {
+        // ',' is a cookie separator if we have later first '=', not ';' or ','
+        lastComma = pos;
+        pos += 1;
+
+        skipWhitespace();
+        nextStart = pos;
+
+        while (pos < cookiesString.length && notSpecialChar()) {
+          pos += 1;
+        }
+
+        // currently special character
+        if (pos < cookiesString.length && cookiesString.charAt(pos) === "=") {
+          // we found cookies separator
+          cookiesSeparatorFound = true;
+          // pos is inside the next cookie, so back up and return it.
+          pos = nextStart;
+          cookiesStrings.push(cookiesString.substring(start, lastComma));
+          start = pos;
+        } else {
+          // in param ',' or param separator ';',
+          // we continue from that comma
+          pos = lastComma + 1;
+        }
+      } else {
+        pos += 1;
+      }
+    }
+
+    if (!cookiesSeparatorFound || pos >= cookiesString.length) {
+      cookiesStrings.push(cookiesString.substring(start, cookiesString.length));
+    }
+  }
+
+  return cookiesStrings;
+}

--- a/packages/libs/lambda-at-edge/tests/headers/normalize-set-cookie-headers.test.ts
+++ b/packages/libs/lambda-at-edge/tests/headers/normalize-set-cookie-headers.test.ts
@@ -1,0 +1,207 @@
+import {
+  normalizeSetCookieHeaders,
+  splitCookiesString
+} from "../../src/headers/normalize-set-cookie-headers";
+
+type CookieSerializeOptions = {
+  [key: string]: string | number | boolean | Date;
+};
+
+const cookieSerialize = (
+  name: string,
+  value: string,
+  opts: CookieSerializeOptions
+) => {
+  const addKeyValuePair = (
+    key: string,
+    value: string | number | boolean | Date
+  ) => (value === true ? `${key}` : `${name}=${value.toString()}`);
+
+  const res = [];
+  res.push(addKeyValuePair(name, value));
+  for (const name in opts) {
+    res.push(addKeyValuePair(name, opts[name]));
+  }
+  return res.join("; ");
+};
+
+function generateCookies(
+  ...cookieOptions: (CookieSerializeOptions & { name: string; value: string })[]
+) {
+  const cookies = cookieOptions.map((opts) =>
+    cookieSerialize(opts.name, opts.value, opts)
+  );
+  return {
+    joined: cookies.join(", "),
+    expected: cookies
+  };
+}
+
+describe("normalizeSetCookieHeaders", () => {
+  const headerName = "set-cookie";
+  const fooSetCookie = `foo=abc--def; path=/; expires=${new Date()}; secure; HttpOnly; SameSite=Lax`;
+  const barSetCookie = `bar=123; path=/; HttpOnly; secure; SameSite=Lax`;
+
+  it("it splits already joined set-cookie headers", () => {
+    const joined = `${fooSetCookie}, ${barSetCookie}`;
+    const cloudFrontHeaders = {
+      [headerName]: [{ key: headerName, value: joined }]
+    };
+    normalizeSetCookieHeaders(cloudFrontHeaders);
+    expect(cloudFrontHeaders).toEqual({
+      [headerName]: [
+        { key: headerName, value: fooSetCookie },
+        { key: headerName, value: barSetCookie }
+      ]
+    });
+  });
+
+  it("respects separated set-cookie headers", () => {
+    const joined = `${fooSetCookie}, ${barSetCookie}`;
+    const standAlone = `stand_alone=123; path=/; HttpOnly; secure; SameSite=Lax`;
+
+    const cloudFrontHeaders = {
+      [headerName]: [
+        { key: headerName, value: joined },
+        { key: headerName, value: standAlone }
+      ]
+    };
+    normalizeSetCookieHeaders(cloudFrontHeaders);
+    expect(cloudFrontHeaders).toEqual({
+      [headerName]: [
+        { key: headerName, value: fooSetCookie },
+        { key: headerName, value: barSetCookie },
+        { key: headerName, value: standAlone }
+      ]
+    });
+  });
+});
+
+describe("splitCookiesString", () => {
+  describe("with a single cookie", () => {
+    it("should parse a plain value", () => {
+      const { joined, expected } = generateCookies({
+        name: "foo",
+        value: "bar"
+      });
+      const result = splitCookiesString(joined);
+      expect(result).toEqual(expected);
+    });
+
+    it("should parse expires", () => {
+      const { joined, expected } = generateCookies({
+        name: "foo",
+        value: "bar",
+        expires: new Date()
+      });
+      const result = splitCookiesString(joined);
+      expect(result).toEqual(expected);
+    });
+
+    it("should parse max-age", () => {
+      const { joined, expected } = generateCookies({
+        name: "foo",
+        value: "bar",
+        maxAge: 10
+      });
+      const result = splitCookiesString(joined);
+      expect(result).toEqual(expected);
+    });
+
+    it("should parse with all the options", () => {
+      const { joined, expected } = generateCookies({
+        name: "foo",
+        value: "bar",
+        expires: new Date(Date.now() + 10 * 1000),
+        maxAge: 10,
+        domain: "https://foo.bar",
+        httpOnly: true,
+        path: "/path",
+        sameSite: "lax",
+        secure: true
+      });
+      const result = splitCookiesString(joined);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("with a mutliple cookies", () => {
+    it("should parse a plain value", () => {
+      const { joined, expected } = generateCookies(
+        {
+          name: "foo",
+          value: "bar"
+        },
+        {
+          name: "x",
+          value: "y"
+        }
+      );
+      const result = splitCookiesString(joined);
+      expect(result).toEqual(expected);
+    });
+
+    it("should parse expires", () => {
+      const { joined, expected } = generateCookies(
+        {
+          name: "foo",
+          value: "bar",
+          expires: new Date()
+        },
+        {
+          name: "x",
+          value: "y",
+          expires: new Date()
+        }
+      );
+      const result = splitCookiesString(joined);
+      expect(result).toEqual(expected);
+    });
+
+    it("should parse max-age", () => {
+      const { joined, expected } = generateCookies(
+        {
+          name: "foo",
+          value: "bar",
+          maxAge: 10
+        },
+        {
+          name: "x",
+          value: "y",
+          maxAge: 10
+        }
+      );
+      const result = splitCookiesString(joined);
+      expect(result).toEqual(expected);
+    });
+
+    it("should parse with all the options", () => {
+      const { joined, expected } = generateCookies(
+        {
+          name: "foo",
+          value: "bar",
+          expires: new Date(Date.now() + 10 * 1000),
+          maxAge: 10,
+          domain: "https://foo.bar",
+          httpOnly: true,
+          path: "/path",
+          sameSite: "lax",
+          secure: true
+        },
+        {
+          name: "x",
+          value: "y",
+          expires: new Date(Date.now() + 20 * 1000),
+          maxAge: 20,
+          domain: "https://x.y",
+          httpOnly: true,
+          path: "/path",
+          sameSite: "strict",
+          secure: true
+        }
+      );
+      const result = splitCookiesString(joined);
+      expect(result).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
**Edge Function breaks Set-Cookie header**

the issue:
`Set-Cookie` headers are combined into a single header and single string value after reading them `headers.entries()` or manipulating them.

result:
```
set-cookie: foo=abc, bar=123
```

however, these merged values are not supported by most the browsers

from the [fetch spec](https://fetch.spec.whatwg.org/#headers-class):

> Unlike a [header list](https://fetch.spec.whatwg.org/#concept-header-list), a [Headers](https://fetch.spec.whatwg.org/#headers) object cannot represent more than one `Set-Cookie` [header](https://fetch.spec.whatwg.org/#concept-header). In a way this is problematic as unlike all other headers `Set-Cookie` headers cannot be combined, but since `Set-Cookie` headers are not exposed to client-side JavaScript this is deemed an acceptable compromise. Implementations could choose the more efficient [Headers](https://fetch.spec.whatwg.org/#headers) object representation even for a [header list](https://fetch.spec.whatwg.org/#concept-header-list), as long as they also support an associated data structure for `Set-Cookie` headers.

so we need to split `Set-Cookie` headers before sending them to the browsers:
```
set-cookie: foo=abc
set-cookie: bar=123
```

the idea goes from [this Nextjs PR](https://github.com/vercel/next.js/pull/30560)