### PR TITLE
Fix: Support encoded content during request proxying

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/compat-layers/apigw-lambda-compat/package.json
+++ b/packages/compat-layers/apigw-lambda-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/next-aws-lambda",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Compat layer between next.js serverless page and AWS Lambda",
   "files": [
     "lib/**",

--- a/packages/compat-layers/lambda-at-edge-compat/package.json
+++ b/packages/compat-layers/lambda-at-edge-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/next-aws-cloudfront",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Compat layer for running next.js apps in Lambda@Edge",
   "main": "next-aws-cloudfront.js",
   "types": "next-aws-cloudfront.d.ts",

--- a/packages/libs/aws-common/package.json
+++ b/packages/libs/aws-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-common",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Common AWS code that is used in Lambda, Lambda@Edge and other AWS platforms.",
   "main": "dist/index.js",
   "module": "dist/module/index.js",

--- a/packages/libs/cloudfront/package.json
+++ b/packages/libs/cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/cloudfront",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Handles CloudFront invalidation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/core/package.json
+++ b/packages/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/core",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Handles Next.js routing independent of provider",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/package.json
+++ b/packages/libs/lambda-at-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/lambda-at-edge",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Provides handlers that can be used in CloudFront Lambda@Edge to deploy next.js applications to the edge",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/libs/lambda-at-edge/src/routing/rewriter.ts
+++ b/packages/libs/lambda-at-edge/src/routing/rewriter.ts
@@ -72,6 +72,7 @@ export async function createExternalRewriteResponse(
       headers: reqHeaders,
       method: req.method,
       body: decodedBody, // Must pass body as a string,
+      compress: false,
       redirect: "manual"
     });
   } else {

--- a/packages/libs/lambda/package.json
+++ b/packages/libs/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/lambda",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Code to build and deploy for Lambda + API Gateway",
   "main": "dist/index.js",
   "module": "dist/module/index.js",

--- a/packages/libs/s3-static-assets/package.json
+++ b/packages/libs/s3-static-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/s3-static-assets",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Handles upload to S3 of next.js static assets",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/serverless-components/aws-cloudfront/package.json
+++ b/packages/serverless-components/aws-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-cloudfront",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",
   "scripts": {

--- a/packages/serverless-components/aws-lambda/package.json
+++ b/packages/serverless-components/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-lambda",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "main": "serverless.js",
   "keywords": [
     "AWS",

--- a/packages/serverless-components/aws-s3/package.json
+++ b/packages/serverless-components/aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-s3",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "main": "./serverless.js",
   "scripts": {
     "lint": "eslint . --fix --cache",

--- a/packages/serverless-components/aws-sqs/package.json
+++ b/packages/serverless-components/aws-sqs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/aws-sqs",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "main": "serverless.js",
   "scripts": {
     "test": "jest"

--- a/packages/serverless-components/domain/package.json
+++ b/packages/serverless-components/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/domain",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "main": "serverless.js",
   "scripts": {
     "clean": "yarn rimraf dist",

--- a/packages/serverless-components/nextjs-cdk-construct/package.json
+++ b/packages/serverless-components/nextjs-cdk-construct/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sls-next/cdk-construct",
   "description": "Serverless Next.js powered by AWS CDK",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Henry Kirkness <henry@planes.studio>",

--- a/packages/serverless-components/nextjs-component/package.json
+++ b/packages/serverless-components/nextjs-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sls-next/serverless-component",
-  "version": "3.8.0-alpha.0-republic.3",
+  "version": "3.8.0-alpha.0-republic.4",
   "description": "Serverless Next.js powered by Serverless Components",
   "main": "./serverless.js",
   "types": "dist/component.d.ts",


### PR DESCRIPTION
Serverless-nextjs decodes responses from origin but does not update headers (for POST requests).
This causes `ERR_CONTENT_DECODING_FAILED` in browsers.